### PR TITLE
WebHookでSlack連携出来るように勝手に改造

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# project file
+.idea
+target

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,12 @@
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/com.slack.api/bolt -->
+        <dependency>
+            <groupId>com.slack.api</groupId>
+            <artifactId>bolt</artifactId>
+            <version>1.7.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/net/mikitaro/nicehash/AutoWithdrawForSlackApplication.java
+++ b/src/main/java/net/mikitaro/nicehash/AutoWithdrawForSlackApplication.java
@@ -1,0 +1,82 @@
+package net.mikitaro.nicehash;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import net.mikitaro.nicehash.domain.external.Api;
+import net.mikitaro.nicehash.domain.external.Slack;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AutoWithdrawForSlackApplication implements RequestHandler<Map<String, Object>, Map<String, Object>> {
+
+    static final String URL_ROOT = "https://api2.nicehash.com/"; // NiceHash 本番APIのURLです。
+    static final String ORG_ID = System.getenv("ORG_ID"); // API Keys の Organization ID
+    static final String API_KEY = System.getenv("API_KEY");// API Key
+    static final String API_SECRET = System.getenv("API_SECRET");// API Secret
+    static final BigDecimal WITHDRAW_THRESHOLD = new BigDecimal(System.getenv("WITHDRAW_THRESHOLD")); // 送金する閾値です。
+    static final BigDecimal WITHDRAW_AMOUNT = new BigDecimal(System.getenv("WITHDRAW_AMOUNT")); // 送金する金額です。
+    static final String WITHDRAW_ADDRESS_ID = System.getenv("WITHDRAW_ADDRESS_ID");// withdraw address の ID
+    static final String WEBHOOK_URL = System.getenv("WEBHOOK_URL");// 結果送信用のSlack webhook URL
+
+    /**
+     * AWS Lambda のハンドラーメソッドです。
+     *
+     * @param input   入力データ
+     * @param context AWS Lambda Context オブジェクト
+     * @return 出力データ
+     */
+    @Override
+    public Map<String, Object> handleRequest(Map<String, Object> input, Context context) {
+        Map<String, Object> output = new HashMap<>();
+        output.put("input", input); // 入力情報を見たいので出力に含める
+        output.put("context", context); // コンテキスト情報を見たいので出力に含める
+
+        Api api = new Api(URL_ROOT, ORG_ID, API_KEY, API_SECRET);
+        Slack slack = new Slack(WEBHOOK_URL);
+
+        String timeResponse = api.get("api/v2/time");
+        JsonObject timeObject = new Gson().fromJson(timeResponse, JsonObject.class);
+        String time = timeObject.get("serverTime").getAsString();
+        System.out.println("server time: " + time);
+
+        String activityResponse = api.get("main/api/v2/accounting/account2/BTC", true, time);
+        JsonObject accountsArray = new Gson().fromJson(activityResponse, JsonObject.class);
+        System.out.println("BTC balance: " + accountsArray.get("available").toString());
+        String replacedBalanceStr = accountsArray.get("available").toString().replaceAll("\"", "");
+        BigDecimal balance = new BigDecimal(replacedBalanceStr);
+
+        if (0 <= balance.compareTo(WITHDRAW_THRESHOLD)) {
+            // 送金対象
+            System.out.println("送金対象");
+        } else {
+            System.out.println("送金しない");
+            slack.post("no withdraw balance = " + balance.toString());
+            return output;
+        }
+        String feeResponse = api.get("main/api/v2/public/service/fee/info", false, time);
+        JsonObject feeObject = new Gson().fromJson(feeResponse, JsonObject.class);
+        BigDecimal addFee = feeObject.get("withdrawal").getAsJsonObject().get("BITGO").getAsJsonObject().get("rules")
+                .getAsJsonObject().get("BTC").getAsJsonObject().get("intervals").getAsJsonArray().get(0)
+                .getAsJsonObject().get("element").getAsJsonObject().get("sndValue").getAsBigDecimal();
+
+        System.out.println("add fee : " + addFee);
+        if (addFee.compareTo(new BigDecimal("0")) == 0) {
+            withdraw(api, time, balance);
+            slack.post("@here success!! fee = " + addFee.toString());
+        } else {
+            slack.post("no withdraw fee = " + addFee.toString());
+        }
+        return output;
+    }
+
+    private void withdraw(Api api, String time, BigDecimal balance) {
+        BigDecimal withdrawAmount = (WITHDRAW_AMOUNT.compareTo(new BigDecimal("0")) == 0) ? balance : WITHDRAW_AMOUNT;
+        String payload = "{\"currency\": \"BTC\",\"amount\": \"" + withdrawAmount.toString() + "\",\"withdrawalAddressId\": \"" + WITHDRAW_ADDRESS_ID + "\"}";
+        String result = api.post("main/api/v2/accounting/withdrawal", payload, time, true);
+        System.out.println(result);
+    }
+}

--- a/src/main/java/net/mikitaro/nicehash/domain/external/Slack.java
+++ b/src/main/java/net/mikitaro/nicehash/domain/external/Slack.java
@@ -1,0 +1,31 @@
+package net.mikitaro.nicehash.domain.external;
+
+import com.slack.api.webhook.Payload;
+import com.slack.api.webhook.WebhookResponse;
+
+public class Slack {
+
+    private final String webhook;
+
+    public Slack(String webhook) {
+        this.webhook = webhook;
+    }
+
+    public WebhookResponse post(String message) {
+        WebhookResponse response = null;
+        com.slack.api.Slack slack = com.slack.api.Slack.getInstance();
+        Payload payload = Payload.builder().text(message).build();
+
+        try {
+            response = slack.send(this.webhook, payload);
+
+            if (!response.getCode().equals(200)){
+                throw new Exception(response.getCode().toString());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return response;
+    }
+}


### PR DESCRIPTION
べきさんこんにちわー、という訳で勝手に作ってプルリク送らせて頂きますｗ
バージョン表記とかはイジってないのでよしなにやって頂ければと思います

* あまり需要が無いけど自分が使いたかったのでWebHook連携先にSlackを追加
* 一応Classを分けて作っているが、亜種が増えたら統合した方が良いので基本的な作りは現行踏襲
* SlackのWebHook取得方法はこちらを参考にして下さい
  * https://qiita.com/vmmhypervisor/items/18c99624a84df8b31008

環境変数は変更無し、現状は共用でDiscordかSlackどちらかのURLしか記載出来ないようにしてあります
Lambdaで実行する際はハンドラをこちらに変更。
```
net.mikitaro.nicehash.AutoWithdrawForSlackApplication::handleRequest
```

という訳でいつも大変お世話になってますm(_ _)m